### PR TITLE
Security update __init__.py

### DIFF
--- a/smarter/__init__.py
+++ b/smarter/__init__.py
@@ -13,10 +13,17 @@ from . import question_sets
 app = Flask(__name__, instance_relative_config=True)
 
 app.config.from_mapping(
-    SECRET_KEY="dev",
-    DATABASE=os.path.join(app.instance_path, "smarter.sqlite"),
+    # SECURITY NOTICE:
+    # Make sure to set the SECRET_KEY environment variable for production use.
+    # Fallback to 'dev' is only for local development.
+    SECRET_KEY=os.environ.get("SECRET_KEY", "dev"),
+    
+    # DATABASE path can be overridden with DATABASE_URL env variable for production deployments.
+    DATABASE=os.environ.get("DATABASE_URL", os.path.join(app.instance_path, "smarter.sqlite")),
+    
     BETA_VERSION=False
 )
+
 
 app.config.from_pyfile("config.py", silent=True)
 


### PR DESCRIPTION
Secret key was hardcoded to "dev".  A proper secret key shall be added to .env to make it safe and publicly deployable. If it is not present it'll fallback to "dev" so it will work even if you don't do it

sqlite path also changed to make it more secure, database URL can be also added secretly.